### PR TITLE
add new event type ce_notification_form, update passkeys events, remove unused types

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -309,13 +309,6 @@ type TradersHubDashboardFormAction = {
     form_name?: string
 }
 
-type PassKeyEffortlessFormAction = {
-    action?: 'open' | 'close' | 'info_open' | 'info_back' | 'maybe_later' | 'get_started'
-    form_source?: string
-    operating_system?: string
-    app_id?: string
-}
-
 type PassKeyAccountSettingsFormAction = {
     action?:
         | 'open'
@@ -328,6 +321,9 @@ type PassKeyAccountSettingsFormAction = {
         | 'create_passkey_continue_trading'
         | 'error'
         | 'add_more_passkeys'
+        | 'passkey_rename_open'
+        | 'passkey_rename_back'
+        | 'passkey_rename_success'
 
     form_name?: string
     subform_name?: string
@@ -360,6 +356,13 @@ type WalletsMigrationFormAction = {
     error_message?: string
 }
 
+type TNotificationsTrayForm = {
+    action?: 'clear_all' | 'click_cta' | 'close' | 'open'
+    form_name?: 'ce_notification_form'
+    notification_num?: number
+    notification_key?: string
+}
+
 export type TEvents = {
     ce_virtual_signup_form: VirtualSignupForm
     ce_email_verification_form: EmailVerificationForm
@@ -380,9 +383,9 @@ export type TEvents = {
     ce_tradershub_onboarding_form: TradersHubOnboardingFormAction
     ce_upgrade_mt5_banner: UpgradeMT5BannerAction
     ce_tradershub_dashboard_form: TradersHubDashboardFormAction
-    ce_passkey_effortless_form: PassKeyEffortlessFormAction
     ce_passkey_account_settings_form: PassKeyAccountSettingsFormAction
     ce_tradershub_popup: TradersHubPopUpAction
     ce_tradershub_banner: TradersHubBanner
     ce_wallets_migration_form: WalletsMigrationFormAction
+    ce_notification_form: TNotificationsTrayForm
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -348,12 +348,9 @@ type TradersHubBanner = {
     banner_type?: string
 }
 
-type WalletsMigrationFormAction = {
-    action?: 'open' | 'close' | 'step_passed' | 'step_back' | 'error'
+type WalletsHomepageFormAction = {
+    action?: 'open'
     form_name?: string
-    step_num?: number
-    step_codename?: string
-    error_message?: string
 }
 
 type TNotificationsTrayForm = {
@@ -386,6 +383,6 @@ export type TEvents = {
     ce_passkey_account_settings_form: PassKeyAccountSettingsFormAction
     ce_tradershub_popup: TradersHubPopUpAction
     ce_tradershub_banner: TradersHubBanner
-    ce_wallets_migration_form: WalletsMigrationFormAction
+    ce_wallets_homepage_form: WalletsHomepageFormAction
     ce_notification_form: TNotificationsTrayForm
 }


### PR DESCRIPTION
1) Added types for tracking events while open, close notifications tray, clear all or click on notifications cta,
2) Remove types for effortless modal, as the modal is removing from deriv-app
3) added types for renaming passkey
4) Add ce_wallets_homepage_form event with WalletsHomepageFormAction types:
action?: 'open' 
form_name?: string
5) Remove ce_wallets_migration_form event.