### PR TITLE
Ako/ Initialise rudderstack and gb simultaneously

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@growthbook/growthbook": "^1.1.0",
-        "@rudderstack/analytics-js": "^3.5.1"
+        "@rudderstack/analytics-js": "^3.5.1",
+        "uuid": "^10.0.0"
       },
       "devDependencies": {
         "@semantic-release/changelog": "^6.0.3",
@@ -19,6 +20,7 @@
         "@semantic-release/release-notes-generator": "^14.0.0",
         "@types/jest": "^29.5.3",
         "@types/node": "^20.4.1",
+        "@types/uuid": "^10.0.0",
         "husky": "^8.0.3",
         "jest": "^29.6.1",
         "jest-environment-jsdom": "^29.6.1",
@@ -1977,6 +1979,12 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
       "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw==",
+      "dev": true
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
       "dev": true
     },
     "node_modules/@types/yargs": {
@@ -12213,6 +12221,18 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "dev": true
+    },
+    "node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
     },
     "node_modules/v8-to-istanbul": {
       "version": "9.1.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "@semantic-release/release-notes-generator": "^14.0.0",
     "@types/jest": "^29.5.3",
     "@types/node": "^20.4.1",
+    "@types/uuid": "^10.0.0",
     "husky": "^8.0.3",
     "jest": "^29.6.1",
     "jest-environment-jsdom": "^29.6.1",
@@ -50,7 +51,8 @@
   },
   "dependencies": {
     "@growthbook/growthbook": "^1.1.0",
-    "@rudderstack/analytics-js": "^3.5.1"
+    "@rudderstack/analytics-js": "^3.5.1",
+    "uuid": "^10.0.0"
   },
   "engines": {
     "node": "18.x",

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,14 +1,12 @@
-import type { Context } from '@growthbook/growthbook'
 import { Growthbook, GrowthbookConfigs } from './growthbook'
 import { RudderStack } from './rudderstack'
-import { TCoreAttributes, TEvents } from './types'
+import { TCoreAttributes, TEvents, TGrowthbookOptions } from './types'
 
 type Options = {
     growthbookKey?: string
-    growthbookOptions?: Partial<Context>
     growthbookDecryptionKey?: string
     rudderstackKey: string
-    GBAttributes?: TCoreAttributes
+    growthbookOptions?: TGrowthbookOptions
 }
 
 export function createAnalyticsInstance(options?: Options) {
@@ -19,33 +17,35 @@ export function createAnalyticsInstance(options?: Options) {
         event_cache: Array<{ event: keyof TEvents; payload: TEvents[keyof TEvents] }> = [],
         page_view_cache: Array<{ current_page: string; platform: string; user_id: string }> = []
 
-    const initialise = ({
-        growthbookKey,
-        growthbookDecryptionKey,
-        rudderstackKey,
-        GBAttributes = {},
-        growthbookOptions,
-    }: Options) => {
+    const initialise = ({ growthbookKey, growthbookDecryptionKey, rudderstackKey, growthbookOptions }: Options) => {
         try {
             _rudderstack = RudderStack.getRudderStackInstance(rudderstackKey)
-            if (Object.keys(GBAttributes).length > 0)
+            if (growthbookOptions?.attributes && Object.keys(growthbookOptions.attributes).length > 0)
                 core_data = {
                     ...core_data,
-                    ...(GBAttributes.geo_location !== undefined && { country: GBAttributes.country }),
-                    ...(GBAttributes.user_language !== undefined && { user_language: GBAttributes.user_language }),
-                    ...(GBAttributes.account_type !== undefined && { account_type: GBAttributes.account_type }),
-                    ...(GBAttributes.app_id !== undefined && { app_id: GBAttributes.app_id }),
-                    ...(GBAttributes.residence_country !== undefined && {
-                        residence_country: GBAttributes.residence_country,
+                    ...(growthbookOptions?.attributes?.country && { country: growthbookOptions?.attributes.country }),
+                    ...(growthbookOptions?.attributes?.user_language && {
+                        user_language: growthbookOptions?.attributes.user_language,
                     }),
-                    ...(GBAttributes.device_type !== undefined && { device_type: GBAttributes.device_type }),
-                    ...(GBAttributes.url !== undefined && { url: GBAttributes.url }),
+                    ...(growthbookOptions?.attributes?.account_type && {
+                        account_type: growthbookOptions?.attributes.account_type,
+                    }),
+                    ...(growthbookOptions?.attributes?.app_id && { app_id: growthbookOptions?.attributes.app_id }),
+                    ...(growthbookOptions?.attributes?.residence_country && {
+                        residence_country: growthbookOptions?.attributes?.residence_country,
+                    }),
+                    ...(growthbookOptions?.attributes?.device_type && {
+                        device_type: growthbookOptions?.attributes.device_type,
+                    }),
+                    ...(growthbookOptions?.attributes?.url && { url: growthbookOptions?.attributes.url }),
                 }
-            if (!GBAttributes.id) GBAttributes.id = _rudderstack.getAnonymousId()
+            growthbookOptions ??= {}
+            growthbookOptions.attributes ??= {}
+            growthbookOptions.attributes.id ??= _rudderstack.getAnonymousId()
+
             if (growthbookKey) {
                 _growthbook = Growthbook.getGrowthBookInstance(
                     growthbookKey,
-                    GBAttributes,
                     growthbookDecryptionKey,
                     growthbookOptions
                 )
@@ -101,13 +101,14 @@ export function createAnalyticsInstance(options?: Options) {
 
         core_data = {
             ...core_data,
-            ...(geo_location !== undefined && { country }),
-            ...(user_language !== undefined && { user_language }),
-            ...(account_type !== undefined && { account_type }),
-            ...(app_id !== undefined && { app_id }),
-            ...(residence_country !== undefined && { residence_country }),
-            ...(device_type !== undefined && { device_type }),
-            ...(url !== undefined && { url }),
+            ...(country && { country }),
+            ...(geo_location && { geo_location }),
+            ...(user_language && { user_language }),
+            ...(account_type && { account_type }),
+            ...(app_id && { app_id }),
+            ...(residence_country && { residence_country }),
+            ...(device_type && { device_type }),
+            ...(url && { url }),
         }
     }
 

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -8,7 +8,7 @@ type Options = {
     growthbookOptions?: Partial<Context>
     growthbookDecryptionKey?: string
     rudderstackKey: string
-    GBAttributes: TCoreAttributes
+    GBAttributes?: TCoreAttributes
 }
 
 export function createAnalyticsInstance(options?: Options) {

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -1,9 +1,7 @@
 import type { Context } from '@growthbook/growthbook'
 import { Growthbook, GrowthbookConfigs } from './growthbook'
 import { RudderStack } from './rudderstack'
-import { RudderAnalytics } from '@rudderstack/analytics-js'
 import { TCoreAttributes, TEvents } from './types'
-import { v6 as uuidv6 } from 'uuid'
 
 type Options = {
     growthbookKey?: string

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -120,7 +120,7 @@ export function createAnalyticsInstance(options?: Options) {
     ) => _growthbook?.getFeatureValue(id as string, defaultValue)
     const isFeatureOn = (key: string) => _growthbook?.isOn(key)
     const setUrl = (href: string) => _growthbook?.setUrl(href)
-    const getId = () => _rudderstack?.getRudderUserId() || ''
+    const getId = () => _rudderstack?.getUserId() || ''
     /**
      * Pushes page view event to Rudderstack
      *

--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -23,12 +23,12 @@ export function createAnalyticsInstance(options?: Options) {
         growthbookKey,
         growthbookDecryptionKey,
         rudderstackKey,
-        GBAttributes,
+        GBAttributes = {},
         growthbookOptions,
     }: Options) => {
         try {
             _rudderstack = RudderStack.getRudderStackInstance(rudderstackKey)
-            if (GBAttributes)
+            if (Object.keys(GBAttributes).length > 0)
                 core_data = {
                     ...core_data,
                     ...(GBAttributes.geo_location !== undefined && { country: GBAttributes.country }),

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -1,6 +1,6 @@
 import { Context, GrowthBook } from '@growthbook/growthbook'
 import { RudderAnalytics } from '@rudderstack/analytics-js'
-import { TCoreAttributes, TGrowthbookAttributes } from './types'
+import { TCoreAttributes, TGrowthbookAttributes, TGrowthbookOptions } from './types'
 
 export type GrowthbookConfigs = {
     // feature flags for framework needs
@@ -16,18 +16,12 @@ export class Growthbook {
     private static _instance: Growthbook
 
     // we have to pass settings due the specific framework implementation
-    constructor(
-        clientKey: string,
-        decryptionKey: string,
-        settings: Partial<Context> = {},
-        GBAttributes: TCoreAttributes = {}
-    ) {
+    constructor(clientKey: string, decryptionKey: string, growthbookOptions: TGrowthbookOptions = {}) {
         this.GrowthBook = new GrowthBook<GrowthbookConfigs>({
             apiHost: 'https://cdn.growthbook.io',
             clientKey,
             decryptionKey,
             antiFlicker: false,
-            attributes: GBAttributes,
             navigateDelay: 0,
             antiFlickerTimeout: 3500,
             subscribeToChanges: true,
@@ -47,7 +41,7 @@ export class Growthbook {
                     variationId: result.variationId,
                 })
             },
-            ...settings,
+            ...growthbookOptions,
         })
         this.init()
     }
@@ -55,12 +49,11 @@ export class Growthbook {
     // for make instance by singleton
     public static getGrowthBookInstance = (
         clientKey: string,
-        GBAttributes: TCoreAttributes,
         decryptionKey?: string,
-        growthbookOptions?: Partial<Context>
+        growthbookOptions?: TGrowthbookOptions
     ) => {
         if (!Growthbook._instance) {
-            Growthbook._instance = new Growthbook(clientKey, decryptionKey ?? '', growthbookOptions, GBAttributes)
+            Growthbook._instance = new Growthbook(clientKey, decryptionKey ?? '', growthbookOptions)
             return Growthbook._instance
         }
         return Growthbook._instance
@@ -85,18 +78,18 @@ export class Growthbook {
         this.GrowthBook.setAttributes({
             ...CURRENT_ATTRIBUTES,
             id,
-            ...(country !== undefined && { country }),
-            ...(residence_country !== undefined && { residence_country }),
-            ...(user_language !== undefined && { user_language }),
-            ...(device_language !== undefined && { device_language }),
-            ...(device_type !== undefined && { device_type }),
-            ...(utm_source !== undefined && { utm_source }),
-            ...(utm_medium !== undefined && { utm_medium }),
-            ...(utm_campaign !== undefined && { utm_campaign }),
-            ...(is_authorised !== undefined && { is_authorised }),
-            ...(url !== undefined && { url }),
-            ...(domain !== undefined && { domain }),
-            ...(utm_content !== undefined && { utm_content }),
+            ...(country && { country }),
+            ...(residence_country && { residence_country }),
+            ...(user_language && { user_language }),
+            ...(device_language && { device_language }),
+            ...(device_type && { device_type }),
+            ...(utm_source && { utm_source }),
+            ...(utm_medium && { utm_medium }),
+            ...(utm_campaign && { utm_campaign }),
+            ...(is_authorised && { is_authorised }),
+            ...(url && { url }),
+            ...(domain && { domain }),
+            ...(utm_content && { utm_content }),
         })
     }
     getFeatureValue = <K extends keyof GrowthbookConfigs, V extends GrowthbookConfigs[K]>(key: K, defaultValue: V) => {

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -60,12 +60,7 @@ export class Growthbook {
         growthbookOptions?: Partial<Context>
     ) => {
         if (!Growthbook._instance) {
-            Growthbook._instance = new Growthbook(
-                clientKey,
-                (decryptionKey = decryptionKey ?? ''),
-                growthbookOptions,
-                GBAttributes
-            )
+            Growthbook._instance = new Growthbook(clientKey, decryptionKey ?? '', growthbookOptions, GBAttributes)
             return Growthbook._instance
         }
         return Growthbook._instance

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -20,7 +20,7 @@ export class Growthbook {
         clientKey: string,
         decryptionKey: string,
         settings: Partial<Context> = {},
-        GBAttributes: TCoreAttributes
+        GBAttributes?: TCoreAttributes
     ) {
         this.GrowthBook = new GrowthBook<GrowthbookConfigs>({
             apiHost: 'https://cdn.growthbook.io',

--- a/src/growthbook.ts
+++ b/src/growthbook.ts
@@ -20,7 +20,7 @@ export class Growthbook {
         clientKey: string,
         decryptionKey: string,
         settings: Partial<Context> = {},
-        GBAttributes?: TCoreAttributes
+        GBAttributes: TCoreAttributes = {}
     ) {
         this.GrowthBook = new GrowthBook<GrowthbookConfigs>({
             apiHost: 'https://cdn.growthbook.io',

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -7,7 +7,7 @@ export class RudderStack {
     has_identified = false
     has_initialized = false
     current_page = ''
-    rudderstack_annonymous_cookie_key = 'rudder_anonymous_id'
+    rudderstack_anonymous_cookie_key = 'rudder_anonymous_id'
     private static _instance: RudderStack
 
     constructor(RUDDERSTACK_KEY: string) {
@@ -23,7 +23,7 @@ export class RudderStack {
     }
 
     getAnonymousId = () => {
-        return document.cookie.match('(^|;)\\s*' + this.rudderstack_annonymous_cookie_key + '\\s*=\\s*([^;]+)')?.pop()
+        return document.cookie.match('(^|;)\\s*' + this.rudderstack_anonymous_cookie_key + '\\s*=\\s*([^;]+)')?.pop()
     }
 
     setCookieIfNotExists = () => {
@@ -33,7 +33,7 @@ export class RudderStack {
         if (!anonymous_id) {
             const domain_name = window.location.hostname.split('.').slice(-2).join('.')
             // Add the new cookie with domain accessible to all subdomains
-            document.cookie = `${this.rudderstack_annonymous_cookie_key}=${uuidv6()}; path=/; Domain=${domain_name}`
+            document.cookie = `${this.rudderstack_anonymous_cookie_key}=${uuidv6()}; path=/; Domain=${domain_name}`
         }
     }
 
@@ -51,7 +51,7 @@ export class RudderStack {
         if (RUDDERSTACK_KEY) {
             this.setCookieIfNotExists()
             this.analytics.load(RUDDERSTACK_KEY, 'https://deriv-dataplane.rudderstack.com', {
-                externalAnonymousIdCookieName: this.rudderstack_annonymous_cookie_key,
+                externalAnonymousIdCookieName: this.rudderstack_anonymous_cookie_key,
             })
             this.analytics.ready(() => {
                 this.has_initialized = true

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -7,7 +7,6 @@ export class RudderStack {
     has_identified = false
     has_initialized = false
     current_page = ''
-    user_id = ''
     rudderstack_annonymous_cookie_key = 'rudder_anonymous_id'
     private static _instance: RudderStack
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Context } from '@growthbook/growthbook'
+
 export type TGrowthbookAttributes = {
     id: string
     country?: string
@@ -13,6 +15,8 @@ export type TGrowthbookAttributes = {
     utm_content?: string
     residence_country?: string
 }
+
+export type TGrowthbookOptions = Partial<Omit<Context, 'attributes'> & { attributes: TCoreAttributes }>
 export type TCoreAttributes = {
     account_type?: string
     user_id?: string


### PR DESCRIPTION
### Purpose:
- **ID Synchronization**: Adding an ID to GrowthBook at the time of initializing RudderStack.
-  **Fix Growthbook Experiments that are relying on ID**

### Key Changes:
- **Hash Generation**: 
  - A hash will be generated as the anonymous ID.
  - This hash will be used for both RudderStack and GrowthBook.

### Benefits:
- **Parallel Initialization**:
  - By generating the hash upfront, we eliminate the need to wait for RudderStack to generate and return the hash.
  - GrowthBook can be initialized simultaneously with RudderStack, improving efficiency.
