### PR TITLE
fix: add user ip to growthbook options

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -57,6 +57,7 @@ export function createAnalyticsInstance(options?: Options) {
                         device_type: growthbookOptions?.attributes.device_type,
                     }),
                     ...(growthbookOptions?.attributes?.url && { url: growthbookOptions?.attributes.url }),
+                    ...(growthbookOptions?.attributes?.user_ip && { url: growthbookOptions?.attributes.user_ip }),
                 }
             growthbookOptions ??= {}
             growthbookOptions.attributes ??= {}
@@ -97,6 +98,7 @@ export function createAnalyticsInstance(options?: Options) {
         url,
         domain,
         geo_location,
+        user_ip,
     }: TCoreAttributes) => {
         if (!_growthbook && !_rudderstack) return
 
@@ -116,6 +118,7 @@ export function createAnalyticsInstance(options?: Options) {
                 is_authorised,
                 url,
                 domain,
+                user_ip,
             }
             if (user_identity) config.id = user_identity
             _growthbook.setAttributes(config)

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,6 +14,7 @@ export type TGrowthbookAttributes = {
     domain?: string
     utm_content?: string
     residence_country?: string
+    user_ip?: string
 }
 
 export type TGrowthbookOptions = Partial<Omit<Context, 'attributes'> & { attributes: TCoreAttributes }>


### PR DESCRIPTION
**Motivation**
user ip is a needed ip address attribute to filter office ips and also blacklist/whitelist ip

**Changes**
- add user_ip to attributes and core_data
- Cookies.getJSON to not use any so it reference to the right import