### PR TITLE
feat: country selection and cache improvements

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -38,11 +38,12 @@ export function createAnalyticsInstance(options?: Options) {
         }
 
         try {
+            const country = Cookies.get('clients_country') || parsedStatus?.clients_country || CloudflareCountry
             _rudderstack = RudderStack.getRudderStackInstance(rudderstackKey)
             if (growthbookOptions?.attributes && Object.keys(growthbookOptions.attributes).length > 0)
                 core_data = {
                     ...core_data,
-                    ...(growthbookOptions?.attributes?.country && { country: growthbookOptions?.attributes.country }),
+                    ...(growthbookOptions?.attributes?.country && { country: country }),
                     ...(growthbookOptions?.attributes?.user_language && {
                         user_language: growthbookOptions?.attributes.user_language,
                     }),
@@ -61,8 +62,7 @@ export function createAnalyticsInstance(options?: Options) {
             growthbookOptions ??= {}
             growthbookOptions.attributes ??= {}
             growthbookOptions.attributes.id ??= _rudderstack.getAnonymousId()
-            growthbookOptions.attributes.country ??=
-                Cookies.get('clients_country') || parsedStatus?.clients_country || CloudflareCountry
+            growthbookOptions.attributes.country ??= country
 
             if (growthbookKey) {
                 _growthbook = Growthbook.getGrowthBookInstance(

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -1,6 +1,7 @@
 import { RudderAnalytics } from '@rudderstack/analytics-js'
 import { TCoreAttributes, TEvents } from './types'
 import { v6 as uuidv6 } from 'uuid'
+import Cookies from 'js-cookie'
 
 interface AnalyticsEvent {
     name: string
@@ -50,7 +51,7 @@ export class RudderStack {
 
     /** For caching mechanism, Rudderstack  SDK, first page load  */
     handleCachedEvents = () => {
-        const storedEvents = localStorage.getItem('cached_analytics_events')
+        const storedEvents = Cookies.get('cached_analytics_events')
         try {
             if (storedEvents) {
                 let eventQueue: AnalyticsEvent[] = JSON.parse(storedEvents) as AnalyticsEvent[]
@@ -61,7 +62,7 @@ export class RudderStack {
                     })
 
                     eventQueue = []
-                    localStorage.removeItem('cached_analytics_events')
+                    Cookies.remove('cached_analytics_events')
                 }
             }
         } catch (error) {


### PR DESCRIPTION
* With this change we dont need to add country prop to init config of GB anymore.
* We used cookie instead of localstorage to make the cached items globally available in all of the applications.