### PR TITLE
feat: FEWP-249/fix rudderstack issue

### DIFF
--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -74,13 +74,17 @@ export class RudderStack {
 
     init = (RUDDERSTACK_KEY: string) => {
         if (RUDDERSTACK_KEY) {
-            const _define = ((window as any).define(window as any).define = undefined)
+            // @ts-ignore
+            const _define = window.define
+            // @ts-ignore
+            window.define = undefined
             this.setCookieIfNotExists()
             this.analytics.load(RUDDERSTACK_KEY, 'https://deriv-dataplane.rudderstack.com', {
                 externalAnonymousIdCookieName: this.rudderstack_anonymous_cookie_key,
             })
             this.analytics.ready(() => {
-                ;(window as any).define = _define
+                // @ts-ignore
+                window.define = _define
                 this.has_initialized = true
                 this.has_identified = !!(this.getUserId() || this.getAnonymousId())
                 this.handleCachedEvents()

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -74,16 +74,13 @@ export class RudderStack {
 
     init = (RUDDERSTACK_KEY: string) => {
         if (RUDDERSTACK_KEY) {
-            // @ts-ignore
             const _define = window.define
-            // @ts-ignore
             window.define = undefined
             this.setCookieIfNotExists()
             this.analytics.load(RUDDERSTACK_KEY, 'https://deriv-dataplane.rudderstack.com', {
                 externalAnonymousIdCookieName: this.rudderstack_anonymous_cookie_key,
             })
             this.analytics.ready(() => {
-                // @ts-ignore
                 window.define = _define
                 this.has_initialized = true
                 this.has_identified = !!(this.getUserId() || this.getAnonymousId())

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -72,16 +72,22 @@ export class RudderStack {
      * For production environment, ensure that `RUDDERSTACK_PRODUCTION_KEY` and `RUDDERSTACK_URL` is set.
      */
 
-    init = (RUDDERSTACK_KEY: string) => {
+    init = (RUDDERSTACK_KEY: string, disableAMD: boolean = false) => {
         if (RUDDERSTACK_KEY) {
-            const _define = window.define
-            window.define = undefined
+            let _define: any
+            if (disableAMD) {
+                _define = window.define
+                window.define = undefined
+            }
+
             this.setCookieIfNotExists()
             this.analytics.load(RUDDERSTACK_KEY, 'https://deriv-dataplane.rudderstack.com', {
                 externalAnonymousIdCookieName: this.rudderstack_anonymous_cookie_key,
             })
             this.analytics.ready(() => {
-                window.define = _define
+                if (disableAMD) {
+                    window.define = _define
+                }
                 this.has_initialized = true
                 this.has_identified = !!(this.getUserId() || this.getAnonymousId())
                 this.handleCachedEvents()

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,11 @@
 import type { Context } from '@growthbook/growthbook'
 
+declare global {
+    interface Window {
+        define: any
+    }
+}
+
 export type TGrowthbookAttributes = {
     id?: string
     country?: string


### PR DESCRIPTION
## Changes
- Resolved conflict between CleverTap SDK and application's AMD usage in device mode.
  - Temporarily disable `window.define` before loading RudderStack.
  - Restore original `define` function after all device mode destinations are loaded.
  - This fix allows CleverTap to initialize properly without interfering with the application's existing AMD setup.