### PR TITLE
feat: replaced getCountry logic with the one in deriv-utils

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "uuid": "^10.0.0"
       },
       "devDependencies": {
+        "@deriv-com/utils": "^0.0.39",
         "@semantic-release/changelog": "^6.0.3",
         "@semantic-release/github": "^10.0.6",
         "@semantic-release/npm": "^12.0.1",
@@ -693,6 +694,12 @@
       "engines": {
         "node": ">=0.1.90"
       }
+    },
+    "node_modules/@deriv-com/utils": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@deriv-com/utils/-/utils-0.0.39.tgz",
+      "integrity": "sha512-/AmtBDD27KqMTKX6fE5IXRXSLi2+GlDZj2/R4mKhL2zuJ/YORzvfRE6IAc7Ij+huObS5BKGf3mNx7oRkKHN2AQ==",
+      "dev": true
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "homepage": "https://github.com/binary-com/deriv-analytics",
   "devDependencies": {
+    "@deriv-com/utils": "^0.0.39",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/github": "^10.0.6",
     "@semantic-release/npm": "^12.0.1",


### PR DESCRIPTION
## Changes

- Installed `@deriv-com/utils`.
- Updated the logic for fetching the client’s country from Cloudflare, replacing it with the method provided by `@deriv-com/utils`.
- Resolved a bug in Growthbook initialization where the country passed by the consumer app was being ignored.