### PR TITLE
fix: prevent anonymous IDs from being used as user identifiers

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -205,7 +205,6 @@ export function createAnalyticsInstance(options?: Options) {
     const setUrl = (href: string) => _growthbook?.setUrl(href)
     const getId = () => {
         const userId = _rudderstack?.getUserId() || ''
-        // Don't return anonymous IDs as user IDs
         return userId && !isUUID(userId) ? userId : ''
     }
     /**
@@ -217,14 +216,12 @@ export function createAnalyticsInstance(options?: Options) {
         if (!_rudderstack) return
 
         const userId = getId()
-        // Only pass user_id if it's a real user ID, otherwise pass empty string
         _rudderstack?.pageView(current_page, platform, userId, properties)
     }
 
     const identifyEvent = (user_id?: string) => {
         const stored_user_id = user_id || getId()
 
-        // Only identify if we have a real user ID (not anonymous ID)
         if (_rudderstack && stored_user_id && !isUUID(stored_user_id)) {
             _rudderstack?.identifyEvent(stored_user_id as string, { language: core_data?.user_language || 'en' })
         }
@@ -249,7 +246,6 @@ export function createAnalyticsInstance(options?: Options) {
             const payload = {
                 ...core_data,
                 ...analytics_data,
-                // Only include user_id if it's a real user ID
                 ...(userId && { user_id: userId }),
             }
 
@@ -296,7 +292,6 @@ export function createAnalyticsInstance(options?: Options) {
 
 export const Analytics = createAnalyticsInstance()
 
-// UUID validation function
 const isUUID = (str: string): boolean => {
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
     return uuidRegex.test(str)

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -142,7 +142,9 @@ export class RudderStack {
      */
     pageView = (current_page: string, platform = 'Deriv App', user_id: string, properties?: {}) => {
         if (this.has_initialized && this.has_identified && current_page !== this.current_page) {
-            this.analytics.page(platform, current_page, { user_id }, properties)
+            // Only include user_id in properties if it's not empty
+            const pageProperties = user_id ? { user_id, ...properties } : properties
+            this.analytics.page(platform, current_page, pageProperties)
             this.current_page = current_page
         }
     }

--- a/src/rudderstack.ts
+++ b/src/rudderstack.ts
@@ -142,7 +142,6 @@ export class RudderStack {
      */
     pageView = (current_page: string, platform = 'Deriv App', user_id: string, properties?: {}) => {
         if (this.has_initialized && this.has_identified && current_page !== this.current_page) {
-            // Only include user_id in properties if it's not empty
             const pageProperties = user_id ? { user_id, ...properties } : properties
             this.analytics.page(platform, current_page, pageProperties)
             this.current_page = current_page


### PR DESCRIPTION
- Add UUID validation to distinguish between real user IDs and anonymous IDs
- Update getId() to return empty string when stored ID is an anonymous ID
- Modify identifyEvent() to only identify users with real user IDs (non-UUID)
- Update trackEvent() and pageView() to only include user_id when it's a real user ID
- Add UUID validation to setAttributes() for both core_data and Growthbook attributes
- Preserve anonymous tracking capability while ensuring proper user identification

This ensures anonymous IDs are not mistakenly used as user identifiers in downstream analytics destinations while maintaining anonymous activity tracking functionality.chore: reset rudderstack userId after logout