### PR TITLE
chore: removed the dependency on growthbook for setAttribute method

### DIFF
--- a/src/analytics.ts
+++ b/src/analytics.ts
@@ -157,11 +157,11 @@ export function createAnalyticsInstance(options?: Options) {
         account_currency,
         account_mode,
     }: TCoreAttributes) => {
-        if (!_growthbook && !_rudderstack) return
+        if (!_rudderstack) return
 
         const user_identity = user_id ?? getId()
 
-        // Check if we have Growthbook instance
+        // Check if we have Growthbook instance and update its attributes
         if (_growthbook) {
             const config: TGrowthbookAttributes = {
                 country,


### PR DESCRIPTION
### Problem: 
The setAttributes method previously required Growthbook to be enabled to update core_data, forcing projects to enable Growthbook unnecessarily.

### Solution: 
Removed the early return check for Growthbook availability and separated the logic:
Growthbook attributes update only when Growthbook is available
core_data updates independently, allowing partial attribute updates